### PR TITLE
Adjust filter by year range

### DIFF
--- a/src/app/browse-by/browse-by-date-page/browse-by-date-page.component.ts
+++ b/src/app/browse-by/browse-by-date-page/browse-by-date-page.component.ts
@@ -86,7 +86,7 @@ export class BrowseByDatePageComponent extends BrowseByMetadataPageComponent {
    * @param scope           The scope under which to fetch the earliest item for
    */
   updateStartsWithOptions(definition: string, metadataKeys: string[], scope?: string) {
-    const firstItemRD = this.browseService.getFirstItemFor(definition, scope, SortDirection.DESC);
+    const firstItemRD = this.browseService.getFirstItemFor(definition, scope, SortDirection.ASC);
     const lastItemRD = this.browseService.getFirstItemFor(definition, scope, SortDirection.DESC);
     this.subs.push(
       observableCombineLatest([firstItemRD, lastItemRD]).subscribe(([firstItem, lastItem]) => {


### PR DESCRIPTION
## References
Fixes https://github.com/uoregon-libraries/scholarsbank-angular/issues/1

## Description
Previously, the 'Filter by year' dropdown filter would only show the most recent year represented in the works. This fix fills in the years as expected (described below) between the earliest and latest years. 

Expected year filling behavior based on updateStartsWithOptions() docstring:

> In this implementation, it creates a list of years starting from the most recent item or the current year, going all the way back to the earliest date found on an item within this scope. The further back in time, the bigger the change in years become to avoid extremely long lists with a one-year difference. To determine the change in years, the config found under GlobalConfig.BrowseBy is used for this.

## Screenshot
<img width="1152" alt="Year dropdown containing all years from 2018 to 2024" src="https://github.com/user-attachments/assets/223b21a0-1520-4362-9993-f40fa34649ff" />
