### PR TITLE
Tweak breadcrumbs to fix page layouts on pages without breadcrumbs

### DIFF
--- a/src/app/breadcrumbs/breadcrumbs.component.html
+++ b/src/app/breadcrumbs/breadcrumbs.component.html
@@ -1,6 +1,6 @@
 <ng-container *ngVar="(breadcrumbs$ | async) as breadcrumbs">
     <nav *ngIf="(showBreadcrumbs$ | async)" aria-label="breadcrumb" class="nav-breadcrumb">
-        <ol class="container breadcrumb">
+        <ol class="container breadcrumb my-0">
             <ng-container
                     *ngTemplateOutlet="breadcrumbs?.length > 0 ? breadcrumb : activeBreadcrumb; context: {text: 'home.breadcrumbs', url: '/'}"></ng-container>
             <ng-container *ngFor="let bc of breadcrumbs; let last = last;">

--- a/src/app/breadcrumbs/breadcrumbs.component.scss
+++ b/src/app/breadcrumbs/breadcrumbs.component.scss
@@ -4,9 +4,8 @@
 
 .breadcrumb {
   border-radius: 0;
-  margin-top: 22px;
-  padding-bottom: var(--ds-content-spacing / 3);
-  padding-top: var(--ds-content-spacing / 3);
+  padding-bottom: var(--ds-content-spacing / 2);
+  padding-top: var(--ds-content-spacing / 2);
   background-color: var(--ds-breadcrumb-bg);
 }
 

--- a/src/app/root/root.component.html
+++ b/src/app/root/root.component.html
@@ -6,8 +6,8 @@
   <div class="inner-wrapper">
     <ds-system-wide-alert-banner></ds-system-wide-alert-banner>
     <ds-themed-header-navbar-wrapper></ds-themed-header-navbar-wrapper>
-    <main class="main-content main-content-adjust">
-      <ds-themed-breadcrumbs></ds-themed-breadcrumbs>
+    <ds-themed-breadcrumbs></ds-themed-breadcrumbs>
+    <main class="main-content">
 
       <div class="container d-flex justify-content-center align-items-center h-100" *ngIf="shouldShowRouteLoader">
         <ds-themed-loading [showMessage]="false"></ds-themed-loading>

--- a/src/app/shared/search-form/search-form.component-site.scss
+++ b/src/app/shared/search-form/search-form.component-site.scss
@@ -28,7 +28,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    margin-top: 25px;
+    margin-top: calc(var(--ds-content-spacing) * -1);
   }
   
   .overlay {

--- a/src/styles/_global-styles.scss
+++ b/src/styles/_global-styles.scss
@@ -30,10 +30,6 @@ body {
     margin-bottom: var(--ds-content-spacing);
 }
 
-.main-content-adjust {
-    margin-top: -25px !important;
-    margin-bottom: 1.5rem;
-}
 
 .alert.hide {
     padding: 0;


### PR DESCRIPTION
## References
* Fixes https://github.com/uoregon-libraries/scholarsbank-angular/issues/10

## Description
Updates breadcrumb layout so that the main content on pages without breadcrumbs doesn't get hidden behind the headers (in particular the Forgot Password or the New user registration pages).

## Instructions for Reviewers
Because I updated the breadcrumb layout instead of fixing the individual pages that were having issues, this change affected the whole site. Please check to see if there are any pages that were affected negatively (both logged in and logged out).

List of changes in this PR:
* Moves breadcrumbs out of the main tag on all pages (as it is in DSpace 7.6.1)
* Adjusts margins on affected elements on the Home page 

## Screenshots
<img width="934" alt="Fixed Forgot Password screen" src="https://github.com/user-attachments/assets/2d8f1dc4-d3f8-4dec-9533-75f6b0fb6bd3" />

<img width="935" alt="Fixed new user registration screen" src="https://github.com/user-attachments/assets/c53f6649-72f9-4bdd-a16b-d27bb13d3dfc" />

